### PR TITLE
Draft: Add draw grid with clicks mode via context menu

### DIFF
--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -14,6 +14,7 @@ import {
 import {
   centringClicksLeft,
   drawGrid,
+  drawGridWithClicks,
   saveImageSize,
   setAperture,
   setCurrentPhase,
@@ -69,6 +70,12 @@ export function toggleDrawGrid() {
       return;
     }
     dispatch(drawGrid());
+  };
+}
+
+export function toggleDrawGridWithClicks(x = 0, y = 0) {
+  return async (dispatch) => {
+    dispatch(drawGridWithClicks({ x, y }));
   };
 }
 
@@ -192,7 +199,10 @@ export function toggleCentring() {
   return async (dispatch, getState) => {
     const { sampleview } = getState();
 
-    // Turn off grid drawing if active
+    // Turn off grid drawings if active
+    if (sampleview.drawGridWithClicks) {
+      dispatch(drawGridWithClicks());
+    }
     if (sampleview.drawGrid) {
       dispatch(drawGrid());
     }

--- a/ui/src/components/SampleView/ContextMenu.jsx
+++ b/ui/src/components/SampleView/ContextMenu.jsx
@@ -12,6 +12,7 @@ import {
   moveToBeam,
   moveToPoint,
   toggleDrawGrid,
+  toggleDrawGridWithClicks,
 } from '../../actions/sampleview';
 import { showTaskForm } from '../../actions/taskForm';
 import { hideMenu } from '../../reducers/contextMenu';
@@ -46,7 +47,9 @@ export default function ContextMenu() {
   const sampleData = useAppSelector(
     (state) => state.sampleGrid.sampleList[sampleID],
   );
-  const { clickCentring } = useAppSelector((state) => state.sampleview);
+  const { clickCentring, drawGrid, drawGridWithClicks } = useAppSelector(
+    (state) => state.sampleview,
+  );
   const groupFolder = useAppSelector((state) => state.queue.groupFolder);
   const contextMenu = useAppSelector((state) => state.contextMenu);
   const { pageX, pageY, sampleViewX, sampleViewY, shape } =
@@ -309,7 +312,17 @@ export default function ContextMenu() {
         genericTasks.line.length > 0 ? { text: 'divider', key: 3 } : {},
         { text: 'Delete Line', action: () => removeShape(), key: 4 },
       ],
-      GridGroup: [{ text: 'Save Grid', action: () => saveGrid(), key: 1 }],
+      GridGroup: [
+        { text: 'Save Grid', action: () => saveGrid(), key: 1 },
+        drawGrid &&
+          drawGridWithClicks && {
+            text: 'End drawing',
+            action: () => {
+              dispatch(toggleDrawGridWithClicks());
+            },
+            key: 2,
+          },
+      ],
       GridGroupSaved: [
         enableNativeMesh
           ? {
@@ -353,14 +366,22 @@ export default function ContextMenu() {
           },
           key: 3,
         },
+        drawGrid &&
+          !drawGridWithClicks && {
+            text: 'Start drawing',
+            action: () => {
+              dispatch(toggleDrawGridWithClicks(sampleViewX, sampleViewY));
+            },
+            key: 4,
+          },
         ...(enable2DPoints
           ? [
-              { text: 'divider', key: 4 },
+              { text: 'divider', key: 5 },
               availableMethods.has('datacollection')
                 ? {
                     text: 'Data Collection (Limited OSC)',
                     action: () => createPointAndShowModal('DataCollection'),
-                    key: 5,
+                    key: 6,
                   }
                 : {},
               availableMethods.has('characterisation')
@@ -370,17 +391,17 @@ export default function ContextMenu() {
                       createPointAndShowModal('Characterisation', {
                         num_imags: 1,
                       }),
-                    key: 6,
+                    key: 7,
                   }
                 : {},
               {
                 text: 'Create 2D Point',
                 action: () => createTwoDPoint(),
-                key: 7,
+                key: 8,
               },
             ]
           : []),
-        { text: 'divider', key: 8 },
+        { text: 'divider', key: 9 },
         ...genericTasks.none,
       ],
     };

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -121,7 +121,9 @@ class SampleImage extends React.Component {
       drawGridWithClicksCoords,
       imageRatio,
       sampleVerticalMotorValue,
+      sampleVerticalMotorState,
       sampleHorizontalMotorValue,
+      sampleHorizontalMotorState,
       pixelsPerMm,
       width,
     } = this.props;
@@ -137,25 +139,44 @@ class SampleImage extends React.Component {
       this.drawGridPlugin.endDrawing();
     }
 
-    // When drawing with clicks and motors move,
-    // shift the grid's start corner to follow the sample
+    // In case motors move while drawing with clicks shift the grid's start corner
     if (this.drawGridPlugin.drawing && drawGridWithClicks) {
-      const prevV = prevProps.sampleVerticalMotorValue;
-      const prevH = prevProps.sampleHorizontalMotorValue;
+      // Record the starting position of the grid before motors moved
       if (
-        prevV !== undefined &&
-        prevH !== undefined &&
-        (sampleVerticalMotorValue !== prevV ||
-          sampleHorizontalMotorValue !== prevH)
+        prevProps.sampleHorizontalMotorState === 'READY' &&
+        sampleHorizontalMotorState === 'BUSY'
       ) {
-        const deltaX =
-          (sampleHorizontalMotorValue - prevH) * pixelsPerMm[0] * imageRatio;
-        const deltaY =
-          -(sampleVerticalMotorValue - prevV) * pixelsPerMm[1] * imageRatio;
-        this.drawGridPlugin.currentTopLeftX += deltaX;
-        this.drawGridPlugin.currentTopLeftY += deltaY;
-        this.prevLayerX += deltaX;
-        this.prevLayerY += deltaY;
+        this.motorOriginH = prevProps.sampleHorizontalMotorValue;
+      }
+      if (
+        prevProps.sampleVerticalMotorState === 'READY' &&
+        sampleVerticalMotorState === 'BUSY'
+      ) {
+        this.motorOriginV = prevProps.sampleVerticalMotorValue;
+      }
+      // Calculate deltas and update canvas when motors have stopped
+      const deltaX = this.calculateMotorDelta(
+        prevProps.sampleHorizontalMotorState,
+        sampleHorizontalMotorState,
+        this.motorOriginH,
+        sampleHorizontalMotorValue,
+        imageRatio,
+        pixelsPerMm[0],
+      );
+      const deltaY = this.calculateMotorDelta(
+        prevProps.sampleVerticalMotorState,
+        sampleVerticalMotorState,
+        this.motorOriginV,
+        sampleVerticalMotorValue,
+        imageRatio,
+        pixelsPerMm[1],
+        -1,
+      );
+      if (deltaX !== undefined || deltaY !== undefined) {
+        this.drawGridPlugin.currentTopLeftX += deltaX ?? 0;
+        this.drawGridPlugin.currentTopLeftY += deltaY ?? 0;
+        this.prevLayerX += deltaX ?? 0;
+        this.prevLayerY += deltaY ?? 0;
         this.drawGridPlugin.update(
           this.canvas,
           this.prevLayerX,
@@ -191,6 +212,21 @@ class SampleImage extends React.Component {
     imageOverlay.removeEventListener('contextmenu', this.rightClick);
     imageOverlay.removeEventListener('wheel', this.wheel);
     imageOverlay.removeEventListener('dblclick', this.goToBeam);
+  }
+
+  calculateMotorDelta(
+    prevState,
+    state,
+    originPosition,
+    position,
+    imageRatio,
+    pxPerMm,
+    sign = 1,
+  ) {
+    if (prevState === 'BUSY' && state === 'READY') {
+      return sign * (position - originPosition) * pxPerMm * imageRatio;
+    }
+    return undefined;
   }
 
   onMouseMove(options) {
@@ -1005,8 +1041,12 @@ function mapStateToProps(state) {
     videoMessageOverlay: state.sampleview.videoMessageOverlay,
     sampleVerticalMotorValue:
       state.beamline.hardwareObjects[verticalMotorAttr]?.value ?? 0,
+    sampleVerticalMotorState:
+      state.beamline.hardwareObjects[verticalMotorAttr]?.state ?? null,
     sampleHorizontalMotorValue:
       state.beamline.hardwareObjects[horizontalMotorAttr]?.value ?? 0,
+    sampleHorizontalMotorState:
+      state.beamline.hardwareObjects[horizontalMotorAttr]?.state ?? null,
   };
 }
 

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -71,6 +71,8 @@ class SampleImage extends React.Component {
     this.drawGridPlugin = new DrawGridPlugin();
     this.drawGridPlugin.setGridResultFormat(props.meshResultFormat);
     this._keyPressed = null;
+    this.prevLayerX = null;
+    this.prevLayerY = null;
     this.removeShapes = this.removeShapes.bind(this);
   }
 
@@ -114,7 +116,54 @@ class SampleImage extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { imageRatio, width } = this.props;
+    const {
+      drawGridWithClicks,
+      drawGridWithClicksCoords,
+      imageRatio,
+      sampleVerticalMotorValue,
+      sampleHorizontalMotorValue,
+      pixelsPerMm,
+      width,
+    } = this.props;
+
+    if (drawGridWithClicks && !prevProps.drawGridWithClicks) {
+      this.canvas.discardActiveObject();
+      const { x, y } = drawGridWithClicksCoords;
+      this.drawGridPlugin.startDrawing(
+        { e: { layerX: x * imageRatio, layerY: y * imageRatio } },
+        this.canvas,
+      );
+    } else if (!drawGridWithClicks && prevProps.drawGridWithClicks) {
+      this.drawGridPlugin.endDrawing();
+    }
+
+    // When drawing with clicks and motors move,
+    // shift the grid's start corner to follow the sample
+    if (this.drawGridPlugin.drawing && drawGridWithClicks) {
+      const prevV = prevProps.sampleVerticalMotorValue;
+      const prevH = prevProps.sampleHorizontalMotorValue;
+      if (
+        prevV !== undefined &&
+        prevH !== undefined &&
+        (sampleVerticalMotorValue !== prevV ||
+          sampleHorizontalMotorValue !== prevH)
+      ) {
+        const deltaX =
+          (sampleHorizontalMotorValue - prevH) * pixelsPerMm[0] * imageRatio;
+        const deltaY =
+          -(sampleVerticalMotorValue - prevV) * pixelsPerMm[1] * imageRatio;
+        this.drawGridPlugin.currentTopLeftX += deltaX;
+        this.drawGridPlugin.currentTopLeftY += deltaY;
+        this.prevLayerX += deltaX;
+        this.prevLayerY += deltaY;
+        this.drawGridPlugin.update(
+          this.canvas,
+          this.prevLayerX,
+          this.prevLayerY,
+        );
+      }
+    }
+
     if (imageRatio !== prevProps.imageRatio || width !== prevProps.width) {
       this.setImageRatio();
     }
@@ -172,19 +221,22 @@ class SampleImage extends React.Component {
       this.canvas.add(this.centringHorizontalLine);
     }
 
-    if (options.e.buttons === 1 && this.drawGridPlugin.drawing) {
-      this.drawGridPlugin.update(
-        this.canvas,
-        options.e.layerX,
-        options.e.layerY,
-      );
+    if (
+      (options.e.buttons === 1 || this.props.drawGridWithClicks) &&
+      this.drawGridPlugin.drawing
+    ) {
+      this.prevLayerX = options.e.layerX;
+      this.prevLayerY = options.e.layerY;
+      this.drawGridPlugin.update(this.canvas, this.prevLayerX, this.prevLayerY);
     }
 
     this.drawGridPlugin.onCellMouseOver(options, this.canvas);
   }
 
   onMouseUp() {
-    this.drawGridPlugin.endDrawing();
+    if (!this.props.drawGridWithClicks) {
+      this.drawGridPlugin.endDrawing();
+    }
   }
 
   setImageRatio() {
@@ -824,8 +876,9 @@ class SampleImage extends React.Component {
     });
 
     // Grid being defined (being drawn)
-    if (this.drawGridPlugin.shapeGroup) {
-      fabricSelectables.push(this.drawGridPlugin.shapeGroup);
+    // — repaint rebuilds and adds shapeGroup to canvas internally
+    if (this.drawGridPlugin.drawing) {
+      this.drawGridPlugin.repaint(this.canvas);
     }
 
     // Add points last so they are in front of grids
@@ -913,6 +966,17 @@ class SampleImage extends React.Component {
 }
 
 function mapStateToProps(state) {
+  const motorComponents =
+    state.uiproperties.sample_view_motors?.components?.filter(
+      (c) => c.value_type === 'MOTOR',
+    ) ?? [];
+  const verticalMotorAttr = motorComponents.find(
+    (c) => c.role === 'sample_vertical',
+  )?.attribute;
+  const horizontalMotorAttr = motorComponents.find(
+    (c) => c.role === 'sample_horizontal',
+  )?.attribute;
+
   return {
     uiproperties: state.uiproperties,
     hardwareObjects: state.beamline.hardwareObjects,
@@ -932,11 +996,17 @@ function mapStateToProps(state) {
     sourceScale: state.sampleview.sourceScale,
     drawGrid: state.sampleview.drawGrid,
     selectedShapes: selectSelectedShapeIds(state),
+    drawGridWithClicks: state.sampleview.drawGridWithClicks,
+    drawGridWithClicksCoords: state.sampleview.drawGridWithClicksCoords,
     pixelsPerMm: state.sampleview.pixelsPerMm,
     beamPosition: state.sampleview.beamPosition,
     beamShape: state.sampleview.beamShape,
     beamSize: state.sampleview.beamSize,
     videoMessageOverlay: state.sampleview.videoMessageOverlay,
+    sampleVerticalMotorValue:
+      state.beamline.hardwareObjects[verticalMotorAttr]?.value ?? 0,
+    sampleHorizontalMotorValue:
+      state.beamline.hardwareObjects[horizontalMotorAttr]?.value ?? 0,
   };
 }
 

--- a/ui/src/reducers/sampleview.ts
+++ b/ui/src/reducers/sampleview.ts
@@ -80,6 +80,8 @@ interface SampleViewState {
   beamSize: Point2D;
   phaseList: string[];
   drawGrid: boolean;
+  drawGridWithClicks: boolean;
+  drawGridWithClicksCoords: Point2D;
   videoMessageOverlay: VideoOverlayState;
 }
 
@@ -106,6 +108,8 @@ const INITIAL_STATE: SampleViewState = {
   beamSize: { x: 0, y: 0 },
   phaseList: [],
   drawGrid: false,
+  drawGridWithClicks: false,
+  drawGridWithClicksCoords: { x: 0, y: 0 },
   videoMessageOverlay: { show: false, msg: '' },
 };
 
@@ -124,6 +128,12 @@ const sampleViewSlice = createSlice({
     },
     drawGrid(state) {
       state.drawGrid = !state.drawGrid;
+      state.drawGridWithClicks = false;
+      state.drawGridWithClicksCoords = { x: 0, y: 0 };
+    },
+    drawGridWithClicks(state, action: PayloadAction<Point2D | undefined>) {
+      state.drawGridWithClicks = !state.drawGridWithClicks;
+      state.drawGridWithClicksCoords = action.payload ?? { x: 0, y: 0 };
     },
     measureDistance(state, action: PayloadAction<boolean>) {
       state.measureDistance = action.payload;
@@ -203,6 +213,7 @@ export const {
   startClickCentring,
   stopClickCentring,
   drawGrid,
+  drawGridWithClicks,
   measureDistance,
   addDistancePoint,
   saveImageSize,


### PR DESCRIPTION
This PR adds an option to draw large grid by enabling movement of motors while drawing and it's an outcome of [the discussion](https://github.com/mxcube/mxcubeweb/discussions/2025).

This is an additional functionality I called "draw with clicks" since there are more clicks needed than in the default drawing (with drag).
1. Toggle draw mode.
2. Open context menu and choose `Start Drawing`.
3. Without pressing the button move cursor wherever valid. 
4. Move motors with `Sample alignment` controls. The grid starting point sticks to its default position whereas ending point of the grid - to the last valid mouse position, thanks to [this part](https://github.com/mxcube/mxcubeweb/pull/2139/changes#diff-b57cd65b3e02b3081922828b320e1c11711b0343f4846a00cb84981c6fdce211R139-R162).
5. Hover over the `Sample image` and the ending position of the grid will be updated.
6. Eventually, open the context menu one more time to either `Save Grid` or `End drawing` without saving.