### PR TITLE
Removed 'abortFun' from WaitDialog reducer

### DIFF
--- a/ui/src/actions/remoteAccess.js
+++ b/ui/src/actions/remoteAccess.js
@@ -41,7 +41,7 @@ export function requestControl(message) {
           title: 'Asking for control',
           message: 'Please wait while asking for control',
           blocking: true,
-          abortFun: () => dispatch(cancelControlRequest()),
+          abortAction: 'cancelControlRequest',
         }),
       );
     } catch (error) {
@@ -55,7 +55,7 @@ export function requestControl(message) {
   };
 }
 
-function cancelControlRequest() {
+export function cancelControlRequest() {
   return async (dispatch) => {
     await sendCancelControlRequest();
     dispatch(getLoginInfo());

--- a/ui/src/containers/PleaseWaitDialog.tsx
+++ b/ui/src/containers/PleaseWaitDialog.tsx
@@ -1,7 +1,18 @@
 import { Button, Modal, ProgressBar } from 'react-bootstrap';
 
-import { hideWaitDialog } from '../reducers/waitDialog';
+import { stopQueue } from '../actions/queue';
+import { cancelControlRequest } from '../actions/remoteAccess';
+import {
+  hideWaitDialog,
+  type WaitDialogAbortAction,
+} from '../reducers/waitDialog';
 import { useAppDispatch, useAppSelector } from '../ts-store';
+
+// Set of well-known abort actions that can be triggered from the wait dialog.
+const ABORT_ACTIONS: Record<WaitDialogAbortAction, () => () => void> = {
+  cancelControlRequest,
+  stopQueue,
+};
 
 function PleaseWaitDialog() {
   const dispatch = useAppDispatch();
@@ -12,12 +23,12 @@ function PleaseWaitDialog() {
     return null;
   }
 
-  const { blocking, message, abortFun, title } = dialog;
+  const { blocking, message, abortAction, title } = dialog;
   return (
     <Modal
       keyboard={!blocking}
       backdrop={!blocking || 'static'}
-      show
+      show={show}
       onHide={() => dispatch(hideWaitDialog())}
       data-default-styles
     >
@@ -37,7 +48,9 @@ function PleaseWaitDialog() {
           <Button
             variant="outline-secondary"
             onClick={() => {
-              abortFun?.();
+              if (abortAction) {
+                dispatch(ABORT_ACTIONS[abortAction]());
+              }
               dispatch(hideWaitDialog());
             }}
           >

--- a/ui/src/containers/PleaseWaitDialog.tsx
+++ b/ui/src/containers/PleaseWaitDialog.tsx
@@ -13,12 +13,11 @@ function PleaseWaitDialog() {
   }
 
   const { blocking, message, abortFun, title } = dialog;
-
   return (
     <Modal
       keyboard={!blocking}
       backdrop={!blocking || 'static'}
-      show={show}
+      show
       onHide={() => dispatch(hideWaitDialog())}
       data-default-styles
     >

--- a/ui/src/reducers/waitDialog.ts
+++ b/ui/src/reducers/waitDialog.ts
@@ -1,7 +1,13 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
+// Identifies which action to dispatch when the dialog's Cancel button is
+// pressed. A key rather than a function so the store only ever holds
+// serializable values - see ABORT_ACTIONS in PleaseWaitDialog for the
+// lookup table that maps these back to real thunks.
+export type WaitDialogAbortAction = 'cancelControlRequest' | 'stopQueue';
+
 interface ShowWaitDialogPayload {
-  abortFun?: () => void;
+  abortAction?: WaitDialogAbortAction;
   blocking?: boolean;
   message?: string;
   title: string;
@@ -12,7 +18,7 @@ const HIDDEN_STATE = { show: false, dialog: null } as const;
 // The dialog is either open (holding its content) or closed (nothing at all).
 
 interface DialogState {
-  abortFun?: () => void;
+  abortAction?: WaitDialogAbortAction;
   blocking: boolean;
   message: string;
   title: string;
@@ -43,9 +49,9 @@ const waitDialogSlice = createSlice({
         title,
         message = '',
         blocking = false,
-        abortFun,
+        abortAction,
       } = action.payload;
-      return { show: true, dialog: { title, message, blocking, abortFun } };
+      return { show: true, dialog: { title, message, blocking, abortAction } };
     },
     hideWaitDialog: (): WaitDialogSliceState => HIDDEN_STATE,
   },

--- a/ui/src/reducers/waitDialog.ts
+++ b/ui/src/reducers/waitDialog.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 // Identifies which action to dispatch when the dialog's Cancel button is
@@ -13,7 +14,7 @@ interface ShowWaitDialogPayload {
   title: string;
 }
 
-const HIDDEN_STATE = { show: false, dialog: null } as const;
+const INITIAL_STATE = { show: false, dialog: null } as const;
 
 // The dialog is either open (holding its content) or closed (nothing at all).
 
@@ -39,7 +40,7 @@ type WaitDialogSliceState =
 
 const waitDialogSlice = createSlice({
   name: 'waitDialog',
-  initialState: (): WaitDialogSliceState => HIDDEN_STATE,
+  initialState: (): WaitDialogSliceState => INITIAL_STATE,
   reducers: {
     showWaitDialog: (
       _state,
@@ -53,7 +54,9 @@ const waitDialogSlice = createSlice({
       } = action.payload;
       return { show: true, dialog: { title, message, blocking, abortAction } };
     },
-    hideWaitDialog: (): WaitDialogSliceState => HIDDEN_STATE,
+    hideWaitDialog(state) {
+      state.show = false;
+    },
   },
 });
 

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -26,7 +26,6 @@ import {
   getQueue,
   setCurrentSample,
   setSampleAttribute,
-  stopQueue,
 } from './actions/queue';
 import { addChatMessage, getRaState } from './actions/remoteAccess';
 import {
@@ -243,7 +242,7 @@ class ServerIO {
               title: 'Sample changer in operation',
               message: record.message,
               blocking: true,
-              abortFun: () => dispatch(stopQueue()),
+              abortAction: 'stopQueue',
             }),
           );
 
@@ -257,7 +256,7 @@ class ServerIO {
               title: `Loading sample ${record.location}`,
               message: record.message,
               blocking: true,
-              abortFun: () => dispatch(stopQueue()),
+              abortAction: 'stopQueue',
             }),
           );
 
@@ -271,7 +270,7 @@ class ServerIO {
               title: `Unloading sample ${record.location}`,
               message: record.message,
               blocking: true,
-              abortFun: () => dispatch(stopQueue()),
+              abortAction: 'stopQueue',
             }),
           );
 


### PR DESCRIPTION
To be merged on top of https://github.com/mxcube/mxcubeweb/pull/2166

As I don't have access to @mockoocy fork I can't use the branch `mockoocy:pm-typed-waitdialog-reducer` as a base for the PR. This simply suggests a way to get rid of `abortFun`, its not very elegant but it will work nicely as we are actually only using two abort functions: cancelControlRequest' and 'stopQueue'.