### PR TITLE
Adapted Pydantic queue handling to match GPhL workflow, and a bug fix

### DIFF
--- a/demo.yaml/gphl/gphl-workflow.yaml
+++ b/demo.yaml/gphl/gphl-workflow.yaml
@@ -189,7 +189,7 @@ configuration:
   #        Set in gph-setup.xml
   # gphl_subdir is not a workflow option. It is set in gphl-setup.xml
   workflows:
-    "GΦL Acquisition Workflow":
+    "GPhL Acquisition Workflow":
       wfpath: Gphl
       wftype: acquisition
       requires:
@@ -230,7 +230,7 @@ configuration:
             # File name pattern for characterisation data collection
             charpattern: generic
 
-        - title: Phasing (SAD)
+        - title: SAD Phasing
           strategy_type: phasing
           wf_selection: mxexpt
           variants:
@@ -312,7 +312,7 @@ configuration:
             # File name pattern for characterisation data collection
             charpattern: generic
 
-      "GΦL Diffractometer calibration":
+      "GPhL Diffractometer calibration":
         wfpath: Gphl
         wftype: diffractcal
         requires:
@@ -360,7 +360,7 @@ configuration:
               # # Path of file to dump persisted instrumentation configuration. OPTIONAL
               # instcfgout: gphl_diffractcal_out.nml
 
-      "GΦL Translational Calibration":
+      "GPhL Translational Calibration":
         wfpath: Gphl
         wftype: transcal
         requires:

--- a/demo/gphl/gphl-workflow.yml
+++ b/demo/gphl/gphl-workflow.yml
@@ -192,7 +192,7 @@ configuration:
 #        Set in gph-setup.xml
 # gphl_subdir is not a workflow option. It is set in gphl-setup.xml
 workflows:
-  "GΦL Acquisition Workflow":
+  "GPhL Acquisition Workflow":
     wfpath: Gphl
     wftype: acquisition
     requires:
@@ -233,7 +233,7 @@ workflows:
           # File name pattern for characterisation data collection
           charpattern: generic
 
-      - title: Phasing (SAD)
+      - title: SAD Phasing
         strategy_type: phasing
         wf_selection: mxexpt
         variants:
@@ -315,7 +315,7 @@ workflows:
           # File name pattern for characterisation data collection
           charpattern: generic
 
-    "GΦL Diffractometer calibration":
+    "GPhL Diffractometer calibration":
       wfpath: Gphl
       wftype: diffractcal
       requires:
@@ -363,7 +363,7 @@ workflows:
             # # Path of file to dump persisted instrumentation configuration. OPTIONAL
             # instcfgout: gphl_diffractcal_out.nml
 
-    "GΦL Translational Calibration":
+    "GPhL Translational Calibration":
       wfpath: Gphl
       wftype: transcal
       requires:

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -147,7 +147,7 @@ class TaskDataPathModel(BaseModel):
     precision: int = 0
     start_num: int = 0
     num_files: int = 0
-    compression: str = ""
+    compression: bool = False
     path: str = ""
     prefix: str = ""
 

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -762,7 +762,7 @@ class QueueSerializer:
         parameters["path"] = parameters["directory"]
         parameters["subdir"] = self._subdir_from_path(parameters["path"])
         parameters["strategy_name"] = node.strategy_name
-        parameters["label"] = f"GΦL {parameters['strategy_name']}"
+        parameters["label"] = f"GPhL {parameters['strategy_name']}"
         parameters["shape"] = node.shape
         parameters["fileName"] = pt.get_image_file_name().replace(
             "%" + ("%sd" % str(pt.precision)), int(pt.precision) * "#"

--- a/ui/src/components/Tasks/Workflow.jsx
+++ b/ui/src/components/Tasks/Workflow.jsx
@@ -20,7 +20,7 @@ function Workflow(props) {
     const parameters = {
       ...params,
       type: isGphlWorkflow ? 'GphlWorkflow' : 'Workflow',
-      label: params.wfname,
+      label: isGphlWorkflow ? `GPhL ${props.strategy_name}` : params.wfname,
       shape: props.pointID,
       suffix: props.suffix,
     };
@@ -37,11 +37,6 @@ function Workflow(props) {
       'wfpath',
       'suffix',
     ];
-
-    if (isGphlWorkflow) {
-      parameters.strategy_name = props.strategy_name;
-      stringFields.push('strategy_name');
-    }
 
     props.addTask(parameters, stringFields, runNow);
     props.hide();


### PR DESCRIPTION
Changes to fix GPhL-workflow broken with new Pydantic-based queue handling.

NB: two change are not specific for GPhL:

The new validator for the label attribute of workflow parameters allows greek characters and parentheses in labels, which is used by GPhL. Claude promises that any characters with potentially dangerous implications are still banned.

The compression attribute of the PathData model is changed from str to bool. The relevant attribute is a boolean in all the code I could see.