### PR TITLE
Fix: non-exstensible shape object:

### DIFF
--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -666,10 +666,14 @@ class SampleImage extends React.Component {
 
       if (shapeData && include) {
         const selected = !shapeData.selected;
-        shape.active = selected;
+        if (Object.isExtensible(shape)) {
+          shape.active = selected;
+        }
         updatedShapes.push({ ...shapeData, selected });
       } else if (shapeData && !shapeData.selected) {
-        shape.active = true;
+        if (Object.isExtensible(shape)) {
+          shape.active = true;
+        }
         updatedShapes.push({ ...shapeData, selected: true });
       }
     });
@@ -687,7 +691,9 @@ class SampleImage extends React.Component {
       const shape = s;
 
       if (shapeData && shapeData.selected && !include) {
-        shape.active = false;
+        if (Object.isExtensible(shape)) {
+          shape.active = false;
+        }
         updatedShapes.push({ ...shapeData, selected: false });
       }
     });


### PR DESCRIPTION
`selectShape` method is invoked from two different sources: canvas events (e.g. right-click on a shape) and the `GridForm` component's row selection. In the first case, the shape parameter is a fabric.js canvas object, which works fine. In the second case, it's a frozen Redux state object, which caused a crash at the `shape.active = ...` assignment — defining a new active property on a frozen object throws:
Uncaught TypeError: can't define property active: Object is not extensible