### PR TITLE
Fix: characterisation task form

### DIFF
--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -12,9 +12,9 @@ import TaskItemContainer from './TaskItemContainer';
 
 function CharacterisationTaskItem(props) {
   const { index, data, sampleId } = props;
-  const { parameters, diffractionPlan } = data;
+  const { type, parameters, diffractionPlan } = data;
 
-  const { type, fileName, path = '', shape } = parameters;
+  const { fileName, path = '', shape } = parameters;
   const pathEndPart = path.slice(-40);
 
   const dispatch = useDispatch();


### PR DESCRIPTION
`type` actually lives at `sampleList[location].tasks[task_number].type`, not `sampleList[location].tasks[task_number].parameters.type`. Because of this, `handleParamsTableClick` was being called with an undefined type for characterication task items, so the characterisaiton form never appeared.

example of sampleList["1:01"]:
```json
{
  '1:01': {
    cell_no: 1,
    checked: true,
    code: 'matr1_1',
    crystalUUID: 'matr1_1',
    defaultPrefix: 'Sample-1-01',
    defaultSubDir: 'Sample-1-01/',
    image_url: '',
    image_x: '',
    image_y: '',
    loadable: true,
    location: '1:01',
    proteinAcronym: '',
    puck_barcode: '',
    puck_no: 1,
    puck_type: '',
    queueID: 14,
    sampleID: '1:01',
    sampleName: 'Sample-1:01',
    sample_barcode: '',
    sc_state: '',
    state: 0,
    tasks: [
      {
        checked: true,
        diffractionPlan: [],
        diffractionPlanID: -1,
        label: 'CHARACTERISATION',
        name: null,
        parameters: {
          account_rad_damage: true,
          aimed_completness: 0.99,
          aimed_i_sigma: 1,
          aimed_multiplicity: 0,
          auto_res: true,
          base_prefix: '',
          beta: 1,
          burn_osc_interval: 3,
          burn_osc_start: 0,
          cellA: 0,
          cellAlpha: 0,
          cellB: 0,
          cellBeta: 0,
          cellC: 0,
          cellGamma: 0,
          cell_counting: null,
          cell_spacing: null,
          compression: '',
          detector_binning_mode: null,
          detector_distance: 0,
          detector_roi_mode: 0,
          determine_rad_params: false,
          directory: '',
          disable_processing: false,
          energy: 12.4,
          exp_time: 0.05,
          experiment_type: '',
          fileName: 'Sample-1-01_0_####..?',
          first_image: 1,
          fullPath: '/tmp/visitor/id2310424/mxcubewebtest/20240615/RAW_DATA/Sample-1-01/Sample-1-01_0_####..?',
          gamma: 0.06,
          helical: false,
          induce_burn: false,
          kappa: 0.87,
          kappa_phi: 1.04,
          low_res_pass_strat: false,
          mad_prefix: '',
          max_crystal_vdim: 0.05,
          max_crystal_vphi: 90,
          mesh: false,
          mesh_center: null,
          mesh_range: {
            horizontal_range: 0,
            vertical_range: 0
          },
          min_crystal_vdim: 0.05,
          min_crystal_vphi: 0,
          min_dose: 30,
          min_time: 0,
          num_files: 0,
          num_images: 1,
          num_images_per_trigger: 0,
          num_lines: 1,
          num_triggers: 0,
          opt_sad: false,
          osc_range: 1,
          osc_start: 25.6,
          osc_total_range: 0,
          overlap: 0,
          path: '/tmp/visitor/id2310424/mxcubewebtest/20240615/RAW_DATA/Sample-1-01',
          permitted_phi_end: 360,
          permitted_phi_start: 0,
          precision: 0,
          prefix: 'Sample-1-01',
          process_directory: '',
          rad_suscept: 1,
          reference_image_prefix: '',
          resolution: 1.927,
          run_number: 0,
          sad_res: 0.5,
          shape: '2DP1',
          shutterless: false,
          space_group: '',
          start_num: 0,
          strategy_complexity: 'SINGLE',
          strategy_program: 'Optimal',
          sub_wedge_size: 10,
          subdir: 'Sample-1-01',
          suffix: '',
          swNumImages: 0,
          take_snapshots: 0,
          taskIndexList: null,
          transmission: 10,
          use_aimed_multiplicity: 0,
          use_aimed_resolution: 0,
          use_min_dose: 1,
          use_min_time: 0,
          use_permitted_rotation: false,
          wedge_prefix: '',
          wedges: [],
          xds_dir: ''
        },
        queueID: 24,
        sampleID: '1:01',
        sampleQueueID: 14,
        state: 0,
        taskIndex: 0,
        type: 'Characterisation'
      }
    ],
    type: 'Sample'
  }
}
```