### PR TITLE
Fix toggleGridVisibility mutating a read-only grid property directly.

### DIFF
--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -748,16 +748,18 @@ class SampleImage extends React.Component {
 
   toggleGridVisibility(id) {
     const grid = this.props.grids[id];
+    let state;
+    let user_state;
 
     if (grid.state === 'HIDDEN') {
-      grid.state = 'SAVED';
-      grid.user_state = 'SAVED';
+      state = 'SAVED';
+      user_state = 'SAVED';
     } else {
-      grid.state = 'HIDDEN';
-      grid.user_state = 'HIDDEN';
+      state = 'HIDDEN';
+      user_state = 'HIDDEN';
     }
 
-    this.props.updateShapes([grid]);
+    this.props.updateShapes([{ ...grid, state, user_state }]);
   }
 
   renderSampleView() {


### PR DESCRIPTION
Grid object are part of Redux state that shouldn't be mutated. Attempt of the above causes: state is read-only errors. Build a new object via spread instead of mutating the prop directly, then pass that to updateShapes.
Similar to: https://github.com/mxcube/mxcubeweb/pull/2180