### PR TITLE
Add grid row/column resizing to GridForm.

### DIFF
--- a/mxcubeweb/core/adapter/sample_view_adapter.py
+++ b/mxcubeweb/core/adapter/sample_view_adapter.py
@@ -181,14 +181,14 @@ class SampleViewAdapter(AdapterBase):
             namespace="/hwr",
         )
 
-    def _get_grid_center_positions(self, shape_data, x, y):
-        """Get the motor positions for the center of the grid shape."""
+    def _get_grid_centre_positions(self, shape_data, x, y):
+        """Get the motor positions for the centre of the grid shape."""
         x_c = x + (shape_data["num_cols"] / 2.0) * shape_data["cell_width"]
         y_c = y + (shape_data["num_rows"] / 2.0) * shape_data["cell_height"]
-        center_positions = self._ho.get_centred_point_from_coord(
+        centre_positions = self._ho.get_centred_point_from_coord(
             x_c, y_c, return_by_names=True
         )
-        return center_positions
+        return centre_positions
 
     def centring_clicks_left(self):
         return self._click_limit - self._click_count
@@ -337,10 +337,10 @@ class SampleViewAdapter(AdapterBase):
 
                         # We also store the center of the grid
                         if t == "G":
-                            center_positions = self._get_grid_center_positions(
+                            centre_positions = self._get_grid_centre_positions(
                                 shape_data, x, y
                             )
-                            pos.append(center_positions)
+                            pos.append(centre_positions)
 
                         shape = self._ho.add_shape_from_mpos(
                             pos, (x, y), t, state, user_state
@@ -373,11 +373,11 @@ class SampleViewAdapter(AdapterBase):
                             x, y, return_by_names=True
                         )
                         pos.append(mpos)
-                        center_positions = self._get_grid_center_positions(
+                        centre_positions = self._get_grid_centre_positions(
                             shape_data, x, y
                         )
-                        # have to get center position again for move_to_pos
-                        pos.append(center_positions)
+                        # have to get centre position again for move_to_pos
+                        pos.append(centre_positions)
 
                         shape.move_to_mpos(pos, shape_data["screen_coord"])
 

--- a/mxcubeweb/core/adapter/sample_view_adapter.py
+++ b/mxcubeweb/core/adapter/sample_view_adapter.py
@@ -181,6 +181,15 @@ class SampleViewAdapter(AdapterBase):
             namespace="/hwr",
         )
 
+    def _get_grid_center_positions(self, shape_data, x, y):
+        """Get the motor positions for the center of the grid shape."""
+        x_c = x + (shape_data["num_cols"] / 2.0) * shape_data["cell_width"]
+        y_c = y + (shape_data["num_rows"] / 2.0) * shape_data["cell_height"]
+        center_positions = self._ho.get_centred_point_from_coord(
+            x_c, y_c, return_by_names=True
+        )
+        return center_positions
+
     def centring_clicks_left(self):
         return self._click_limit - self._click_count
 
@@ -328,19 +337,8 @@ class SampleViewAdapter(AdapterBase):
 
                         # We also store the center of the grid
                         if t == "G":
-                            # coords for the center of the grid
-                            x_c = (
-                                x
-                                + (shape_data["num_cols"] / 2.0)
-                                * shape_data["cell_width"]
-                            )
-                            y_c = (
-                                y
-                                + (shape_data["num_rows"] / 2.0)
-                                * shape_data["cell_height"]
-                            )
-                            center_positions = self._ho.get_centred_point_from_coord(
-                                x_c, y_c, return_by_names=True
+                            center_positions = self._get_grid_center_positions(
+                                shape_data, x, y
                             )
                             pos.append(center_positions)
 
@@ -358,6 +356,31 @@ class SampleViewAdapter(AdapterBase):
             # shape will be none if creation failed, so we check if shape exists
             # before setting additional parameters
             if shape:
+                # If the shape is a resized grid, we need to update the top left mpos
+                if (
+                    shape_data.get("t", "") == "G"
+                    and "num_cols" in shape_data
+                    and "num_rows" in shape_data
+                ):
+                    # Check if the grid has been resized
+                    grid_resized = (
+                        shape_data["num_cols"] != shape.num_cols
+                        or shape_data["num_rows"] != shape.num_rows
+                    )
+                    if grid_resized:
+                        x, y = shape_data["screen_coord"][:2]
+                        mpos = self._ho.get_centred_point_from_coord(
+                            x, y, return_by_names=True
+                        )
+                        pos.append(mpos)
+                        center_positions = self._get_grid_center_positions(
+                            shape_data, x, y
+                        )
+                        # have to get center position again for move_to_pos
+                        pos.append(center_positions)
+
+                        shape.move_to_mpos(pos, shape_data["screen_coord"])
+
                 shape.update_from_dict(shape_data)
                 shape_dict = to_camel(shape.as_dict())
                 updated_shapes.append(shape_dict)

--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -54,6 +54,7 @@ function _GridData() {
 export default class DrawGridPlugin {
   constructor() {
     this.startDrawing = this.startDrawing.bind(this);
+    this.resize = this.resize.bind(this);
     this.update = this.update.bind(this);
     this.endDrawing = this.endDrawing.bind(this);
     this.repaint = this.repaint.bind(this);
@@ -219,6 +220,37 @@ export default class DrawGridPlugin {
       this.currentTopLeftX = options.e.layerX;
       this.currentTopLeftY = options.e.layerY;
     }
+  }
+
+  resize(canvas, gridData, rows, cols) {
+    // Keep accumulating onto plugins own in-progress copy while the same grid
+    // is being resized, otherwise re-read gridData from Redux. That would
+    // discard whichever row/col edit hasn't been saved yet.
+    if (this.gridData.id !== gridData.id) {
+      this.gridData = {
+        ...gridData,
+        pixelsPerMMX: gridData.pixelsPerMm[0],
+        pixelsPerMMY: gridData.pixelsPerMm[1],
+      };
+    }
+
+    const numRows = Number.parseInt(rows);
+    if (!Number.isNaN(numRows)) {
+      const cellTH =
+        this.getCellHeight(this.gridData) + this.getCellVSpace(this.gridData);
+      this.gridData.height = numRows * cellTH;
+      this.gridData.numRows = numRows;
+    }
+
+    const numCols = Number.parseInt(cols);
+    if (!Number.isNaN(numCols)) {
+      const cellTW =
+        this.getCellWidth(this.gridData) + this.getCellHSpace(this.gridData);
+      this.gridData.width = numCols * cellTW;
+      this.gridData.numCols = numCols;
+    }
+
+    this.repaint(canvas);
   }
 
   /**
@@ -613,8 +645,14 @@ export default class DrawGridPlugin {
    */
   saveGrid(_gd) {
     const gd = structuredClone(_gd);
-    gd.screenCoord[0] /= this.scale;
-    gd.screenCoord[1] /= this.scale;
+    // screenCoord is only in raw screen-pixel units while a grid is being
+    // freshly drawn (id === null, see update()). A grid resized after being
+    // saved (id !== null) already has a normalized screenCoord (see
+    // shapeFromGridData), so it must not be divided again here.
+    if (gd.id === null) {
+      gd.screenCoord[0] /= this.scale;
+      gd.screenCoord[1] /= this.scale;
+    }
     gd.width /= this.scale;
     gd.height /= this.scale;
     return gd;

--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -229,6 +229,7 @@ export default class DrawGridPlugin {
     if (this.gridData.id !== gridData.id) {
       this.gridData = {
         ...gridData,
+        screenCoord: [...gridData.screenCoord],
         pixelsPerMMX: gridData.pixelsPerMm[0],
         pixelsPerMMY: gridData.pixelsPerMm[1],
       };
@@ -236,18 +237,26 @@ export default class DrawGridPlugin {
 
     const numRows = Number.parseInt(rows);
     if (!Number.isNaN(numRows)) {
-      const cellTH =
-        this.getCellHeight(this.gridData) + this.getCellVSpace(this.gridData);
-      this.gridData.height = numRows * cellTH;
+      const prevHeight = this.gridData.height;
+      this.gridData.height =
+        (numRows *
+          this.gridData.pixelsPerMMY *
+          (this.gridData.cellHeight + this.gridData.cellVSpace)) /
+        1000;
       this.gridData.numRows = numRows;
+      this.gridData.screenCoord[1] += (prevHeight - this.gridData.height) / 2;
     }
 
     const numCols = Number.parseInt(cols);
     if (!Number.isNaN(numCols)) {
-      const cellTW =
-        this.getCellWidth(this.gridData) + this.getCellHSpace(this.gridData);
-      this.gridData.width = numCols * cellTW;
+      const prevWidth = this.gridData.width;
+      this.gridData.width =
+        (numCols *
+          this.gridData.pixelsPerMMX *
+          (this.gridData.cellWidth + this.gridData.cellHSpace)) /
+        1000;
       this.gridData.numCols = numCols;
+      this.gridData.screenCoord[0] += (prevWidth - this.gridData.width) / 2;
     }
 
     this.repaint(canvas);
@@ -645,16 +654,15 @@ export default class DrawGridPlugin {
    */
   saveGrid(_gd) {
     const gd = structuredClone(_gd);
-    // screenCoord is only in raw screen-pixel units while a grid is being
-    // freshly drawn (id === null, see update()). A grid resized after being
-    // saved (id !== null) already has a normalized screenCoord (see
-    // shapeFromGridData), so it must not be divided again here.
+    // screenCoord/width/height are only in raw screen-pixel units while a grid
+    // is being freshly drawn (id === null). A grid resized after being saved
+    // (id !== null) is already normalized (see resize()/shapeFromGridData).
     if (gd.id === null) {
       gd.screenCoord[0] /= this.scale;
       gd.screenCoord[1] /= this.scale;
+      gd.width /= this.scale;
+      gd.height /= this.scale;
     }
-    gd.width /= this.scale;
-    gd.height /= this.scale;
     return gd;
   }
 

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -41,6 +41,7 @@ export default function GridForm(props) {
     setGridOverlayOpacity,
     show,
     toggleVisibility,
+    resizeGrid,
   } = props;
 
   const draggableRef = useRef(null);
@@ -96,7 +97,7 @@ export default function GridForm(props) {
           </td>
           <td>{grid.numRows * grid.numCols}</td>
           <td>
-            {grid.numRows}x{grid.numCols}
+            {grid.numRows} x {grid.numCols}
           </td>
           <td>{grid.motorPositions.omega.toFixed(2)}&deg;</td>
           <td>
@@ -177,7 +178,39 @@ export default function GridForm(props) {
         )}
         <td />
         <td />
-        <td />
+        <td className="align-items-center d-flex gap-1">
+          <Form onSubmit={(event) => event.preventDefault()}>
+            <Form.Control
+              key={selectedGrids[0] ?? 'new-grid-rows'}
+              style={{ width: '50px' }}
+              type="text"
+              defaultValue={
+                selectedGrids.length > 0
+                  ? gridList[selectedGrids[0]].numRows
+                  : 10
+              }
+              onChange={(e) => {
+                resizeGrid(e.target.value, null);
+              }}
+            />
+          </Form>
+          x
+          <Form onSubmit={(event) => event.preventDefault()}>
+            <Form.Control
+              key={selectedGrids[0] ?? 'new-grid-cols'}
+              style={{ width: '50px' }}
+              type="text"
+              defaultValue={
+                selectedGrids.length > 0
+                  ? gridList[selectedGrids[0]].numCols
+                  : 10
+              }
+              onChange={(e) => {
+                resizeGrid(null, e.target.value);
+              }}
+            />
+          </Form>
+        </td>
         <td />
         <td />
         <td />
@@ -208,7 +241,7 @@ export default function GridForm(props) {
       cancel="form"
     >
       <Row className={styles.gridForm} ref={draggableRef}>
-        <Col xs={8}>
+        <Col xs={10}>
           <Table striped hover responsive className={styles.gridTable}>
             <thead>
               <tr>
@@ -217,7 +250,7 @@ export default function GridForm(props) {
                 {show_vspace && <th>V-Space (µm)</th>}
                 <th>Dim (µm)</th>
                 <th>#Cells</th>
-                <th>R x C</th>
+                <th className="flex-fill">R x C</th>
                 <th>&Omega;</th>
                 <th />
                 <th />
@@ -227,7 +260,7 @@ export default function GridForm(props) {
             <tbody>{getGridControls()}</tbody>
           </Table>
         </Col>
-        <Col xs={4} style={{ marginTop: '20px' }}>
+        <Col xs={2} style={{ marginTop: '20px' }}>
           <Form>
             <Form.Group className="mb-2" as={Row}>
               <Col sm="4">

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -108,9 +108,7 @@ export default function GridForm(props) {
                 key={`${grid.id}-rows`}
                 style={{ width: '50px' }}
                 type="text"
-                defaultValue={
-                  grid.numRows
-                }
+                defaultValue={grid.numRows}
                 onChange={(e) => {
                   resizeGrid(e.target.value, null);
                 }}
@@ -135,9 +133,7 @@ export default function GridForm(props) {
                 key={`${grid.id}-cols`}
                 style={{ width: '50px' }}
                 type="text"
-                defaultValue={
-                  grid.numCols
-                }
+                defaultValue={grid.numCols}
                 onChange={(e) => {
                   resizeGrid(null, e.target.value);
                 }}

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -42,6 +42,7 @@ export default function GridForm(props) {
     show,
     toggleVisibility,
     resizeGrid,
+    submitResizeGrid,
   } = props;
 
   const draggableRef = useRef(null);
@@ -96,8 +97,60 @@ export default function GridForm(props) {
             {vdim} x {hdim}
           </td>
           <td>{grid.numRows * grid.numCols}</td>
-          <td>
-            {grid.numRows} x {grid.numCols}
+          <td className="align-items-center d-flex gap-1">
+            <Form
+              onSubmit={(event) => {
+                event.preventDefault();
+                submitResizeGrid();
+              }}
+            >
+              <Form.Control
+                key={`${grid.id}-rows`}
+                style={{ width: '50px' }}
+                type="text"
+                defaultValue={
+                  grid.numRows
+                }
+                onChange={(e) => {
+                  resizeGrid(e.target.value, null);
+                }}
+                onFocus={() => {
+                  if (!selected) {
+                    selectGrid([grid], false);
+                  }
+                }}
+                onClick={(e) => e.stopPropagation()}
+                onMouseDown={(e) => e.stopPropagation()}
+                onBlur={(e) => e.currentTarget.form.requestSubmit()}
+              />
+            </Form>
+            x
+            <Form
+              onSubmit={(event) => {
+                event.preventDefault();
+                submitResizeGrid();
+              }}
+            >
+              <Form.Control
+                key={`${grid.id}-cols`}
+                style={{ width: '50px' }}
+                type="text"
+                defaultValue={
+                  grid.numCols
+                }
+                onChange={(e) => {
+                  resizeGrid(null, e.target.value);
+                }}
+                onFocus={() => {
+                  if (!selected) {
+                    selectGrid([grid], false);
+                  }
+                }}
+                onClick={(e) => e.stopPropagation()}
+                onMouseDown={(e) => e.stopPropagation()}
+                onBlur={(e) => e.currentTarget.form.requestSubmit()}
+              />
+            </Form>
           </td>
           <td>{grid.motorPositions.omega.toFixed(2)}&deg;</td>
           <td>
@@ -178,39 +231,7 @@ export default function GridForm(props) {
         )}
         <td />
         <td />
-        <td className="align-items-center d-flex gap-1">
-          <Form onSubmit={(event) => event.preventDefault()}>
-            <Form.Control
-              key={selectedGrids[0] ?? 'new-grid-rows'}
-              style={{ width: '50px' }}
-              type="text"
-              defaultValue={
-                selectedGrids.length > 0
-                  ? gridList[selectedGrids[0]].numRows
-                  : 10
-              }
-              onChange={(e) => {
-                resizeGrid(e.target.value, null);
-              }}
-            />
-          </Form>
-          x
-          <Form onSubmit={(event) => event.preventDefault()}>
-            <Form.Control
-              key={selectedGrids[0] ?? 'new-grid-cols'}
-              style={{ width: '50px' }}
-              type="text"
-              defaultValue={
-                selectedGrids.length > 0
-                  ? gridList[selectedGrids[0]].numCols
-                  : 10
-              }
-              onChange={(e) => {
-                resizeGrid(null, e.target.value);
-              }}
-            />
-          </Form>
-        </td>
+        <td />
         <td />
         <td />
         <td />

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -72,6 +72,7 @@ class SampleImage extends React.Component {
     this.drawGridPlugin.setGridResultFormat(props.meshResultFormat);
     this._keyPressed = null;
     this.removeShapes = this.removeShapes.bind(this);
+    this.resizeGrid = this.resizeGrid.bind(this);
   }
 
   componentDidMount() {
@@ -181,6 +182,11 @@ class SampleImage extends React.Component {
     }
 
     this.drawGridPlugin.onCellMouseOver(options, this.canvas);
+  }
+
+  resizeGrid(rows, cols) {
+    const gridData = this.selectedGrid();
+    this.drawGridPlugin.resize(this.canvas, gridData, rows, cols);
   }
 
   onMouseUp() {
@@ -731,6 +737,7 @@ class SampleImage extends React.Component {
     });
 
     if (updatedShapes.length > 0) {
+      this.drawGridPlugin.reset();
       this.props.updateShapes(updatedShapes);
     }
   }
@@ -893,6 +900,7 @@ class SampleImage extends React.Component {
               rotateTo={this.props.rotateToShape}
               selectGrid={this.selectShape}
               selectedGrids={this.props.selectedGrids.map((grid) => grid.id)}
+              resizeGrid={this.resizeGrid}
             />
             <div className={styles.videoCanvasWrapper}>
               <VideoPlayer />

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -73,6 +73,7 @@ class SampleImage extends React.Component {
     this._keyPressed = null;
     this.removeShapes = this.removeShapes.bind(this);
     this.resizeGrid = this.resizeGrid.bind(this);
+    this.submitResizeGrid = this.submitResizeGrid.bind(this);
   }
 
   componentDidMount() {
@@ -187,6 +188,10 @@ class SampleImage extends React.Component {
   resizeGrid(rows, cols) {
     const gridData = this.selectedGrid();
     this.drawGridPlugin.resize(this.canvas, gridData, rows, cols);
+  }
+
+  submitResizeGrid() {
+    this.props.updateShapes([this.drawGridPlugin.currentGridData()]);
   }
 
   onMouseUp() {
@@ -901,6 +906,7 @@ class SampleImage extends React.Component {
               selectGrid={this.selectShape}
               selectedGrids={this.props.selectedGrids.map((grid) => grid.id)}
               resizeGrid={this.resizeGrid}
+              submitResizeGrid={this.submitResizeGrid}
             />
             <div className={styles.videoCanvasWrapper}>
               <VideoPlayer />


### PR DESCRIPTION
Important details: preserve accumulated row/col edits across successive changes in `DrawGridPlugin.resize`, avoid double-scaling `screenCoord` on save for already-normalized (previously saved) grids.

This is another proposition of how to deal with [large grids](https://github.com/mxcube/mxcubeweb/discussions/2025) by Max IV beamline staff. 

1. Select `Draw grid` and draw it
2. Save
3. Select `Draw Grid` again, select grid that need to be resized and change the number of columns and/or rows.
4. Press '+' to save it = update shape on the backend.

<img width="1841" height="777" alt="Screenshot from 2026-08-11 17-42-28" src="https://github.com/user-attachments/assets/55e5d73d-151d-4d00-bc1c-01bf6ba21aeb" />

I included changes from [this PR ](https://github.com/mxcube/mxcubeweb/pull/2180) for the time being but I will rebase after it is merged.