### PR TITLE
Fix crash when ui_schema is undefined.

### DIFF
--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1,5 +1,6 @@
 import contextlib
 import itertools
+import json
 import logging
 import os
 import re
@@ -613,8 +614,6 @@ class QueueSerializer:
                 debug(q)
                 return
             except Exception:
-                import json
-
                 pretty = json.dumps(q, indent=2, sort_keys=True, ensure_ascii=False)
                 header = msg or "Queue state after addition:"
                 print(f"[QueueSerializer] {header}\n{pretty}")
@@ -2678,9 +2677,9 @@ class Queue(ComponentBase):
         schema = self.get_task_schema(data_model) if data_model else {}
 
         try:
-            ui_schema = data_model.ui_schema() if data_model else {}
-        except Exception:
-            ui_schema = {}
+            ui_schema = data_model.ui_schema() if data_model else json.dumps({})
+        except AttributeError:
+            ui_schema = json.dumps({})
 
         if schema:
             for parameter_group in schema.values():

--- a/test/input_parameters.py
+++ b/test/input_parameters.py
@@ -170,7 +170,7 @@ default_dc_params = {
     "queue_entry": "datacollection",
     "requires": [],
     "schema": {},
-    "ui_schema": {},
+    "ui_schema": "{}",
 }
 
 default_char_acq_params = {
@@ -253,7 +253,7 @@ default_char_acq_params = {
     "queue_entry": "characterisation",
     "requires": [],
     "schema": {},
-    "ui_schema": {},
+    "ui_schema": "{}",
 }
 
 default_mesh_params = {
@@ -306,7 +306,7 @@ default_mesh_params = {
     "queue_entry": "mesh",
     "requires": [],
     "schema": {},
-    "ui_schema": {},
+    "ui_schema": "{}",
 }
 
 
@@ -360,5 +360,5 @@ default_xrf_parameters = {
     "queue_entry": "xrf_spectrum",
     "requires": [],
     "schema": {},
-    "ui_schema": {},
+    "ui_schema": "{}",
 }


### PR DESCRIPTION
Current code tries to foresee a situation where data_model.ui_schema is not defined. The fallback value `{}` does not work, as frontend expects a stringified json to parse.