### PR TITLE
refactor logging config options, change command line

### DIFF
--- a/mxcubeweb/__init__.py
+++ b/mxcubeweb/__init__.py
@@ -18,7 +18,7 @@ from mxcubecore import HardwareRepository as HWR  # noqa: E402
 from mxcubeweb.app import MXCUBEApplication as mxcube  # noqa: E402
 from mxcubeweb.config import Config  # noqa: E402
 from mxcubeweb.core.models.configmodels import RuntimeOptions  # noqa: E402
-
+from mxcubeweb.logging_handler import LOGGER_NAMES  # noqa: E402
 from mxcubeweb.core.server.server import create_server  # noqa: E402
 from mxcubeweb.core.server.routes import register_routes  # noqa: E402
 
@@ -67,24 +67,13 @@ def parse_args(argv):
     )
 
     opt_parser.add_argument(
-        "-el",
+        "-e",
         "--enabled-loggers",
         dest="enabled_logger_list",
-        help=(
-            "Which loggers to use, default is to use all loggers"
-            " ([exception_logger, hwr_logger, server_logger,"
-            " user_logger, queue_logger])"
-        ),
-        default=[
-            "exception_logger",
-            "hwr_logger",
-            "server_logger",
-            "user_logger",
-            "queue_logger",
-            "ui_logger",
-            "csp_logger",
-            "server_access_logger",
-        ],
+        nargs="+",
+        choices=LOGGER_NAMES,
+        default=LOGGER_NAMES,
+        help="Loggers to enable; by default all loggers are enabled.",
     )
 
     opt_parser.add_argument(
@@ -93,6 +82,15 @@ def parse_args(argv):
         action="store_true",
         dest="allow_remote",
         help="Enable remote access",
+        default=False,
+    )
+
+    opt_parser.add_argument(
+        "-t",
+        "--ra-timeout",
+        action="store_true",
+        dest="ra_timeout",
+        help="Timeout gives control",
         default=False,
     )
 
@@ -144,6 +142,7 @@ def build_server_and_config(test=False, argv=None):
         mxcube.init(
             server,
             runtime_options.allow_remote,
+            runtime_options.ra_timeout,
             runtime_options.log_file,
             runtime_options.log_level,
             runtime_options.enabled_logger_list,

--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -33,7 +33,7 @@ from mxcubeweb.core.components.workflow import Workflow
 from mxcubeweb.core.components.lims import Lims
 from mxcubeweb.core.components.log import Log
 from mxcubeweb.core.models.configmodels import UIComponentModel
-from mxcubeweb.logging_handler import MX3LoggingHandler
+from mxcubeweb.logging_handler import MX3LoggingHandler, LOGGER_NAMES_MAP
 from mxcubeweb.core.server.resource_handler import ResourceHandlerFactory
 
 removeLoggingHandlers()
@@ -79,9 +79,19 @@ class MXCUBEApplication:
     # Enabled or Disable remote usage
     ALLOW_REMOTE = False
 
+    # Enable timeout gives control (if ALLOW_REMOTE is True)
+    TIMEOUT_GIVES_CONTROL = False
+
     # Enable automatic Mountie of sample when queue executed in
     # "automatic/pipeline" mode
     AUTO_MOUNT_SAMPLE = False
+
+    # Automatically add and execute diffraction plans coming from
+    # characterizations
+    AUTO_ADD_DIFFPLAN = False
+
+    # Number of sample snapshots taken before collect
+    DEFAULT_NUM_SNAPSHOTS = 4
 
     # Remember collection paramters between samples
     # or reset (defualt) between samples.
@@ -101,6 +111,7 @@ class MXCUBEApplication:
     def init(
         server,
         allow_remote,
+        ra_timeout,
         log_fpath,
         log_level,
         enabled_logger_list,
@@ -110,6 +121,7 @@ class MXCUBEApplication:
 
         Params:
             allow_remote(bool): Allow remote usage, ``True`` else ``False``.
+            ra_timeout(bool): Timeout gives control, ``True`` else ``False``.
         """
         # The routes created by the AdapterResourceHandler
         # via the factory are kept between calls to init as they
@@ -124,6 +136,7 @@ class MXCUBEApplication:
         logging.getLogger("MX3.HWR").info("Starting MXCuBE-Web...")
         MXCUBEApplication.server = server
         MXCUBEApplication.ALLOW_REMOTE = allow_remote
+        MXCUBEApplication.TIMEOUT_GIVES_CONTROL = ra_timeout
         MXCUBEApplication.CONFIG = cfg
         MXCUBEApplication.mxcubecore = HardwareObjectAdapterManager(MXCUBEApplication)
 
@@ -277,17 +290,7 @@ class MXCUBEApplication:
         stdout_handler = StreamHandler(sys.stdout)
         stdout_handler.setFormatter(console_fmt)
 
-        logger_map = {
-            "hwr_logger": "HWR",
-            "server_logger": "MX3.HWR",
-            "user_logger": "user_level_log",
-            "queue_logger": "queue_exec",
-            "ui_logger": "MX3.UI",
-            "csp_logger": "csp",
-            "server_access_logger": "server_access",
-        }
-
-        for attr, name in logger_map.items():
+        for attr, name in LOGGER_NAMES_MAP.items():
             logger = logging.getLogger(name)
 
             if attr in enabled_logger_list:

--- a/mxcubeweb/logging_handler.py
+++ b/mxcubeweb/logging_handler.py
@@ -1,6 +1,18 @@
 import logging
 import uuid
 
+LOGGER_NAMES_MAP = {
+    "csp_logger": "csp",
+    "exception_logger": "ex_logger",
+    "hwr_logger": "HWR",
+    "queue_logger": "queue_exec",
+    "server_access_logger": "server_access",
+    "server_logger": "MX3.HWR",
+    "ui_logger": "MX3.UI",
+    "user_logger": "user_level_log",
+}
+LOGGER_NAMES = list(LOGGER_NAMES_MAP.keys())
+
 
 class MX3LoggingHandler(logging.handlers.BufferingHandler):
     def __init__(self, server):


### PR DESCRIPTION
- ATTENTION: renamed short argparse flag from "-el" to "-e" as this is very unnatural and may eventually conflict in case we ever add a "-e" option since there is already a "-l"
- refactored logging handler names and map into the logging_handler consolidating the source of names into one place
- the "--enabled-loggers" has also been updated so it checks for typos by using "choices"