### PR TITLE
Operate on values of DiffractometerPhase enum rather than names.

### DIFF
--- a/mxcubeweb/core/adapter/diffractometer_adapter.py
+++ b/mxcubeweb/core/adapter/diffractometer_adapter.py
@@ -50,7 +50,7 @@ class DiffractometerAdapter(AdapterBase):
 
     def get_value(self) -> dict:
         return {
-            "currentPhase": self._ho.get_phase().name,
+            "currentPhase": self._ho.get_phase().value,
             "phaseList": self._ho.get_phase_list(),
         }
 

--- a/ui/cypress/e2e/motors.cy.js
+++ b/ui/cypress/e2e/motors.cy.js
@@ -6,8 +6,8 @@ describe('Motors', () => {
   });
 
   it('can control motors', () => {
-    cy.findByLabelText('Phase Control').select('COLLECT');
-    cy.findByLabelText('Phase Control').should('have.value', 'COLLECT');
+    cy.findByLabelText('Phase Control').select('DataCollection');
+    cy.findByLabelText('Phase Control').should('have.value', 'DataCollection');
 
     cy.findByLabelText('Beam size').select('A20');
     cy.findByLabelText('Beam size').should('have.value', 'A20');

--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -16,7 +16,6 @@ import {
   drawGrid,
   saveImageSize,
   setAperture,
-  setCurrentPhase,
   showVideoMessageOverlay,
   startClickCentring as startClickCentringAction,
   stopClickCentring,
@@ -263,10 +262,9 @@ export function changeAperture(size) {
 }
 
 export function changeCurrentPhase(phase) {
-  return async (dispatch) => {
+  return async () => {
     await sendExecuteCommand('diffractometer', 'diffractometer', 'set_phase', {
       phase,
     });
-    dispatch(setCurrentPhase(phase));
   };
 }


### PR DESCRIPTION
Enum names are supposed to be of internal use. They are also less human-friendly, especially given that they are currently being provided to the UI in the PhaseInput component.

---
marked as draft, as it depends on https://github.com/mxcube/mxcubecore/pull/1669
the python test should also pass afterwards.